### PR TITLE
Allow fetch_model to check for model presence before querying DB

### DIFF
--- a/lib/pathway/plugins/sequel_models.rb
+++ b/lib/pathway/plugins/sequel_models.rb
@@ -35,9 +35,13 @@ module Pathway
         extend Forwardable
         delegate %i[model_class db field] => 'self.class'
 
-        def fetch_model(state, from: model_class, key: field, column: field)
-          find_model_with(state[:input][key], from, column)
-            .then { |model| state.update(result_key => model) }
+        def fetch_model(state, from: model_class, key: field, column: field, rewrite: false)
+          if state[result_key].nil? || rewrite
+            find_model_with(state[:input][key], from, column)
+              .then { |model| state.update(result_key => model) }
+          else
+            state
+          end
         end
 
         def build_model_with(params)

--- a/lib/pathway/version.rb
+++ b/lib/pathway/version.rb
@@ -1,3 +1,3 @@
 module Pathway
-  VERSION = '0.0.11'
+  VERSION = '0.0.12'
 end

--- a/spec/plugins/sequel_models_spec.rb
+++ b/spec/plugins/sequel_models_spec.rb
@@ -40,64 +40,111 @@ module Pathway
         end
       end
 
-      describe '.[]' do
-        context 'when including the resulting module' do
-          it 'resets the :result_key using the model class name' do
-            expect(operation.result_key).to eq(:my_model)
-          end
+      context 'when Finder[] with a model class is included' do
+        it 'resets the :result_key using the model class name' do
+          expect(operation.result_key).to eq(:my_model)
+        end
 
-          it "defines instance methods returning the config options", :aggregate_failures do
-            expect(operation.model_class).to eq(MyModel)
-            expect(operation.field).to eq(:email)
-            expect(operation.db).to eq(DB)
-          end
+        it "defines instance methods returning the config options", :aggregate_failures do
+          expect(operation.model_class).to eq(MyModel)
+          expect(operation.field).to eq(:email)
+          expect(operation.db).to eq(DB)
+        end
 
-          let(:key)    { "some@email.com" }
-          let(:params) { { foo: 3, bar: 4} }
-          let(:object) { double }
+        let(:key)    { "some@email.com" }
+        let(:params) { { foo: 3, bar: 4} }
+        let(:object) { double }
 
-          it "defines instance method 'find_model_with' to invoke model_class" do
-            expect(MyModel).to receive(:first).with(email: key)
+        it "defines instance method 'find_model_with' to invoke model_class" do
+          expect(MyModel).to receive(:first).with(email: key)
 
-            operation.find_model_with(key)
-          end
+          operation.find_model_with(key)
+        end
 
-          it "defines instance method 'build_model_with' to build model from model_class" do
-            expect(MyModel).to receive(:new).with(params)
+        it "defines instance method 'build_model_with' to build model from model_class" do
+          expect(MyModel).to receive(:new).with(params)
 
-            operation.build_model_with(params)
-          end
+          operation.build_model_with(params)
+        end
 
-          let(:repository) { double }
+        let(:repository) { double }
 
-          it "defines instance method 'fetch_model' step to fetch object from model_class into result key" do
-            expect(repository).to receive(:first).with(pk: 'foo').and_return(object)
-            expect(MyModel).to_not receive(:first)
+        it "defines instance method 'fetch_model' step to fetch object from model_class into result key" do
+          expect(repository).to receive(:first).with(pk: 'foo').and_return(object)
+          expect(MyModel).to_not receive(:first)
 
-            result = operation
-                       .fetch_model({input: {myid: 'foo'}}, from: repository, key: :myid, column: :pk)
-                       .value[:my_model]
+          result = operation
+                     .fetch_model({input: {myid: 'foo'}}, from: repository, key: :myid, column: :pk)
+                     .value[:my_model]
 
-            expect(result).to eq(object)
-          end
+          expect(result).to eq(object)
+        end
 
 
-          it "defines instance method 'fetch_model' step to fetch object from model_class into result key using default arguments when none specified" do
-            expect(MyModel).to receive(:first).with(email: key).and_return(object)
+        it "defines instance method 'fetch_model' step to fetch object from model_class into result key using default arguments when none specified" do
+          expect(MyModel).to receive(:first).with(email: key).and_return(object)
 
-            expect(operation.fetch_model(input: {email: key}).value[:my_model]).to eq(object)
-          end
+          expect(operation.fetch_model(input: {email: key}).value[:my_model]).to eq(object)
+        end
 
-          it "defines instance method 'fetch_model' to return error when object is missing", :aggregate_failures do
-            allow(MyModel).to receive(:first).with(email: key).and_return(nil)
+        it "defines instance method 'fetch_model' to return error when object is missing", :aggregate_failures do
+          allow(MyModel).to receive(:first).with(email: key).and_return(nil)
 
-            expect(operation.fetch_model(input: {email: key})).to be_an(Result::Failure)
-            expect(operation.fetch_model(input: {email: key}).error).to be_an(Pathway::Error)
-            expect(operation.fetch_model(input: {email: key}).error.type).to eq(:not_found)
+          expect(operation.fetch_model(input: {email: key})).to be_an(Result::Failure)
+          expect(operation.fetch_model(input: {email: key}).error).to be_an(Pathway::Error)
+          expect(operation.fetch_model(input: {email: key}).error.type).to eq(:not_found)
+        end
+      end
+
+      describe '#call' do
+        class CtxOperation < MyOperation
+          context my_model: nil
+        end
+
+        let(:operation)     { CtxOperation.new(ctx) }
+        let(:result)        { operation.call(email: 'an@email.com') }
+        let(:fetched_model) { MyModel.new }
+
+        context "when the model is not present at the context" do
+          let(:ctx) { {} }
+          it "fetchs the model from the DB" do
+            expect(MyModel).to receive(:first).with(email: 'an@email.com').and_return(fetched_model)
+
+            expect(result.value).to be(fetched_model)
           end
         end
 
+        context "when the model is already present in the context" do
+          let(:existing_model) { MyModel.new }
+          let(:ctx)            { { my_model: existing_model } }
+
+          it "uses the model from the context and avoid querying the DB" do
+            expect(MyModel).to_not receive(:first)
+
+            expect(result.value).to be(existing_model)
+          end
+
+          context "but rewrite: option in step is true" do
+            class RewOperation < CtxOperation
+              context my_model: nil
+
+              process do
+                step :fetch_model, rewrite: true
+              end
+            end
+
+            let(:operation) { RewOperation.new(ctx) }
+
+            it "fetches the model from the DB anyway" do
+              expect(MyModel).to receive(:first).with(email: 'an@email.com').and_return(fetched_model)
+
+              expect(operation.my_model).to be(existing_model)
+              expect(result.value).to be(fetched_model)
+            end
+          end
+        end
       end
     end
+
   end
 end


### PR DESCRIPTION
- When using `sequel_models` plugin, don't fetch the DB if the model is already loaded in context.
- Improve plugin tests