### PR TITLE
Fix Typo: Missing "do" keyword after params

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Let's see a few examples:
 
 ```ruby
 class NuggetContract < Dry::Validation::Contract
-  params
+  params do
     required(:owner).filled(:string)
     required(:price).filled(:integer)
   end


### PR DESCRIPTION
Without "do" word, example code produces "syntax error, unexpected end, expecting end-of-input"