### PR TITLE
Add support for Ruby 3.0

### DIFF
--- a/lib/pathway/plugins/auto_deconstruct_state.rb
+++ b/lib/pathway/plugins/auto_deconstruct_state.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+if RUBY_VERSION =~ /^3\./
+  require 'pathway/plugins/auto_deconstruct_state/ruby3'
+end
+
+module Pathway
+  module Plugins
+    module AutoDeconstructState
+    end
+  end
+end

--- a/lib/pathway/plugins/auto_deconstruct_state/ruby3.rb
+++ b/lib/pathway/plugins/auto_deconstruct_state/ruby3.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Pathway
+  module Plugins
+    module AutoDeconstructState
+      module DSLMethods
+        private
+
+        def _callable(callable)
+          if callable.is_a?(Symbol) && @operation.respond_to?(callable, true) &&
+            @operation.method(callable).parameters.all? { _1 in [:key|:keyreq|:keyrest|:block,*] }
+
+            -> state { @operation.send(callable, **state) }
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pathway/plugins/dry_validation/v1_0.rb
+++ b/lib/pathway/plugins/dry_validation/v1_0.rb
@@ -19,7 +19,7 @@ module Pathway
             end
           end
 
-          def params(*args, &block)
+          ruby2_keywords def params(*args, &block)
             contract { params(*args, &block) }
           end
 
@@ -29,8 +29,8 @@ module Pathway
             @builded_contract = @contract_options.empty? && klass.schema ? klass.new : nil
           end
 
-          def build_contract(opts = {})
-            @builded_contract || contract_class.new(opts)
+          def build_contract(**opts)
+            @builded_contract || contract_class.new(**opts)
           end
 
           def inherited(subclass)
@@ -57,12 +57,12 @@ module Pathway
               with ||= contract_options.zip(contract_options).to_h
             end
             opts = Hash(with).map { |to, from| [to, state[from]] }.to_h
-            validate_with(state[:input], opts)
+            validate_with(state[:input], **opts)
               .then { |params| state.update(params: params) }
           end
 
-          def validate_with(input, opts = {})
-            result = contract(opts).call(input)
+          def validate_with(input, **opts)
+            result = contract(**opts).call(input)
 
             result.success? ? wrap(result.values.to_h) : error(:validation, details: result.errors.to_h)
           end

--- a/lib/pathway/plugins/responder.rb
+++ b/lib/pathway/plugins/responder.rb
@@ -4,8 +4,8 @@ module Pathway
   module Plugins
     module Responder
       module ClassMethods
-        def call(ctx, *params, &bl)
-          result = super(ctx, *params)
+        ruby2_keywords def call(*args, &bl)
+          result = super(*args)
           block_given? ? Responder.respond(result, &bl) : result
         end
       end

--- a/lib/pathway/plugins/sequel_models.rb
+++ b/lib/pathway/plugins/sequel_models.rb
@@ -84,8 +84,8 @@ module Pathway
         end
       end
 
-      def self.apply(operation, model: nil, **args)
-        operation.model(model, args) if model
+      def self.apply(operation, model: nil, **kwargs)
+        operation.model(model, **kwargs) if model
       end
     end
   end

--- a/pathway.gemspec
+++ b/pathway.gemspec
@@ -31,10 +31,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "dry-inflector", ">= 0.1.0"
   spec.add_dependency "contextualizer", "~> 0.0.4"
+  spec.add_dependency "ruby2_keywords"
 
   spec.add_development_dependency "dry-validation", ">= 0.11"
   spec.add_development_dependency "bundler", "~> 2.3.7"
-  spec.add_development_dependency "sequel", "~> 5.25.0"
+  spec.add_development_dependency "sequel", "~> 5.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.11"
   spec.add_development_dependency "simplecov-lcov", '~> 0.8.0'

--- a/spec/plugins/auto_deconstruct_state_spec.rb
+++ b/spec/plugins/auto_deconstruct_state_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Pathway
+  module Plugins
+    describe 'AutoDeconstructState' do
+      class KwargsOperation < Operation
+        if RUBY_VERSION =~ /^3\./
+          plugin :auto_deconstruct_state
+        end
+
+        context :validator, :name_repo, :email_repo, :notifier
+
+        process do
+          step :custom_validate
+          step :fetch_and_set_name, with: :id
+          set  :fetch_email, to: :email
+          set  :create_model
+          step :notify
+        end
+
+        def custom_validate(state)
+          state[:params] = @validator.call(state[:input])
+        end
+
+        def fetch_and_set_name(state, with:)
+          state[:name] = @name_repo.call(state[:params][with])
+        end
+
+        def fetch_email(name:, **, &_)
+          @email_repo.call(name)
+        end
+
+        def create_model(name:, email:, **)
+          UserModel.new(name, email)
+        end
+
+        def notify(value:, **)
+          @notifier.call(value)
+        end
+      end
+
+      UserModel = Struct.new(:name, :email)
+
+      describe "#call" do
+        subject(:operation) { KwargsOperation.new(ctx) }
+
+        let(:ctx)        { { validator: validator, name_repo: name_repo, email_repo: email_repo, notifier: notifier } }
+        let(:name)       { 'Paul Smith' }
+        let(:email)      { 'psmith@email.com' }
+        let(:input)      { { id: 99 } }
+
+        let(:validator) do
+          double.tap do |val|
+            allow(val).to receive(:call) do |input_arg|
+              expect(input_arg).to eq(input)
+
+              input
+            end
+          end
+        end
+
+        let(:name_repo) do
+          double.tap do |repo|
+            allow(repo).to receive(:call).with(99).and_return(name)
+          end
+        end
+
+        let(:email_repo) do
+          double.tap do |repo|
+            allow(repo).to receive(:call).with(name).and_return(email)
+          end
+        end
+
+        let(:notifier) do
+          double.tap do |repo|
+            allow(repo).to receive(:call) do |value|
+              expect(value).to be_a(UserModel).and(have_attributes(name: name, email: email))
+            end
+          end
+        end
+
+        it 'destructure arguments on steps with only kwargs', :aggregate_failures do
+          operation.call(input)
+        end
+      end
+    end
+  end
+end

--- a/spec/plugins/base_spec.rb
+++ b/spec/plugins/base_spec.rb
@@ -34,8 +34,8 @@ module Pathway
           state[:params] = @validator.call(state)
         end
 
-        def get_value(params:, **)
-          @back_end.call(params)
+        def get_value(state)
+          @back_end.call(state[:params])
         end
 
         def get_aux_value(state)
@@ -68,7 +68,8 @@ module Pathway
       subject(:operation) { OperationWithSteps.new(ctx) }
 
       before do
-        allow(validator).to receive(:call) do |input:, **|
+        allow(validator).to receive(:call) do |state|
+          input = state[:input]
           input.key?(:foo) ? input : Result.failure(:validation)
         end
 

--- a/spec/plugins/dry_validation/1_0_spec.rb
+++ b/spec/plugins/dry_validation/1_0_spec.rb
@@ -26,11 +26,12 @@ module Pathway
 
         private
 
-        def fetch_profile(params:,**)
-          wrap_if_present(repository.fetch(params))
+        def fetch_profile(state)
+          wrap_if_present(repository.fetch(state[:params]))
         end
 
-        def create_model(params:, profile:,**)
+        def create_model(state)
+          params, profile = state.values_at(:params, :profile)
           SimpleModel.new(*params.values, user.role, profile)
         end
       end

--- a/spec/plugins/sequel_models_spec.rb
+++ b/spec/plugins/sequel_models_spec.rb
@@ -39,8 +39,8 @@ module Pathway
           state[:my_model] = { model: state[:my_model] }
         end
 
-        def send_emails(my_model:,**)
-          @mailer.send_emails(my_model) if @mailer
+        def send_emails(state)
+          @mailer.send_emails(state[:my_model]) if @mailer
         end
       end
 
@@ -53,8 +53,8 @@ module Pathway
           end
         end
 
-        def chain_operation(input:,**)
-          MailerOperation.call(context, input)
+        def chain_operation(state)
+          MailerOperation.call(context, state[:input])
         end
       end
 
@@ -187,8 +187,8 @@ module Pathway
                 end
               end
 
-              def send_emails(my_model:,**)
-                @mailer.send_emails(my_model) if @mailer
+              def send_emails(state)
+                @mailer.send_emails(state[:my_model]) if @mailer
               end
             end
 
@@ -310,7 +310,7 @@ module Pathway
         it "fetches an instance through 'model_class' into result key" do
           expect(MyModel).to receive(:first).with(email: key).and_return(object)
 
-          expect(operation.fetch_model(input: {email: key}).value[:my_model]).to eq(object)
+          expect(operation.fetch_model({input: {email: key}}).value[:my_model]).to eq(object)
         end
 
         context "when proving and external repository through 'from:'" do
@@ -364,7 +364,7 @@ module Pathway
         it 'returns an error when no instance is found', :aggregate_failures do
           expect(MyModel).to receive(:first).with(email: key).and_return(nil)
 
-          result = operation.fetch_model(input: {email: key})
+          result = operation.fetch_model({input: {email: key}})
 
           expect(result).to be_an(Result::Failure)
           expect(result.error).to be_an(Pathway::Error)
@@ -375,7 +375,7 @@ module Pathway
         it 'returns an error without hitting the database when search key is nil', :aggregate_failures do
           expect(MyModel).to_not receive(:first)
 
-          result = operation.fetch_model(input: {email: nil})
+          result = operation.fetch_model({input: {email: nil}})
 
           expect(result).to be_an(Result::Failure)
           expect(result.error).to be_an(Pathway::Error)


### PR DESCRIPTION
Add support for Ruby 3.0 and add `:auto_deconstruct_state` to help porting legacy code from Ruby 2.x.